### PR TITLE
[frontend] feat: table filtering (single select)

### DIFF
--- a/frontend/src/components/navigation/Navbar.tsx
+++ b/frontend/src/components/navigation/Navbar.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Flex, Text, useColorMode, useColorModeValue } from '@chakra-ui/react';
+import { Box, Button, Flex, HStack, Text, useColorMode, useColorModeValue } from '@chakra-ui/react';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 import React from 'react';
+import { FaCode } from 'react-icons/fa';
 import { Link } from 'react-router-dom';
 
 const Navbar: React.FC = () => {
@@ -9,7 +10,10 @@ const Navbar: React.FC = () => {
     <Box backgroundColor={useColorModeValue('gray.100', 'gray.900')} px={8}>
       <Flex height={16} alignItems="center" justifyContent="space-between">
         <Link to="/">
-          <Text fontWeight="bold">PeerPrep</Text>
+          <HStack>
+            <FaCode />
+            <Text fontWeight="bold">PeerPrep</Text>
+          </HStack>
         </Link>
         <Button onClick={toggleColorMode}>{colorMode === 'light' ? <MoonIcon /> : <SunIcon />}</Button>
       </Flex>

--- a/frontend/src/components/tables/DataTable.tsx
+++ b/frontend/src/components/tables/DataTable.tsx
@@ -1,4 +1,4 @@
-import { Card, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react';
+import { Card, Stack, Table, Tbody, Td, Text, Tr } from '@chakra-ui/react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -14,6 +14,7 @@ import React, { useState } from 'react';
 import DataTablePagination from './DataTablePagination';
 import DataTableHeader from './DataTableHeader';
 import DataTableSearch from './DataTableSearch';
+import DataTableSelectFilter from './DataTableSelectFilter';
 
 interface DataTableProps<T extends object> {
   /* The data collection to be displayed by the table */
@@ -61,7 +62,19 @@ const DataTable = <T extends object>({
 
   return (
     <>
-      {isSortable && <DataTableSearch table={table} />}
+      <Stack direction="row" alignItems="end" marginBottom={6}>
+        {isSortable && <DataTableSearch table={table} />}
+        {table.getHeaderGroups().map((headerGroup) =>
+          headerGroup.headers.map((header) => {
+            const column = header.column;
+            if (column.columnDef.meta === undefined) return null;
+            if ('selectFilterOptions' in column.columnDef.meta) {
+              return <DataTableSelectFilter key={column.id} column={column} />;
+            } else return null;
+          }),
+        )}
+      </Stack>
+
       <Card variant="outline">
         <Table size="sm">
           <DataTableHeader headerGroups={table.getHeaderGroups()} isSortable={isSortable} />

--- a/frontend/src/components/tables/DataTableSearch.tsx
+++ b/frontend/src/components/tables/DataTableSearch.tsx
@@ -1,5 +1,5 @@
 import { CloseIcon, SearchIcon } from '@chakra-ui/icons';
-import { Box, Input, InputGroup, InputLeftElement, InputRightElement, useColorModeValue } from '@chakra-ui/react';
+import { Input, InputGroup, InputLeftElement, InputRightElement, useColorModeValue } from '@chakra-ui/react';
 import { type Table } from '@tanstack/react-table';
 import React, { useEffect, useState } from 'react';
 
@@ -23,33 +23,31 @@ const DataTableSearch = <T extends object>({ table }: DataTableSearchProps<T>): 
   }, [searchValue]);
 
   return (
-    <Box marginBottom={6}>
-      <InputGroup>
-        <InputLeftElement paddingLeft={8} pointerEvents="none">
-          <SearchIcon color="gray.400" />
-        </InputLeftElement>
+    <InputGroup minWidth={700}>
+      <InputLeftElement paddingLeft={8} pointerEvents="none">
+        <SearchIcon color="gray.400" />
+      </InputLeftElement>
 
-        <Input
-          paddingLeft={16}
-          type="text"
-          placeholder="Search Question List"
-          _placeholder={{ color: useColorModeValue('gray.500', 'gray.400'), opacity: 1 }}
-          value={searchValue ?? ''}
-          onChange={(e) => {
-            setSearchValue(e.target.value);
-          }}
-        />
+      <Input
+        paddingLeft={16}
+        type="text"
+        placeholder="Search Question List"
+        _placeholder={{ color: useColorModeValue('gray.500', 'gray.400'), opacity: 1 }}
+        value={searchValue ?? ''}
+        onChange={(e) => {
+          setSearchValue(e.target.value);
+        }}
+      />
 
-        <InputRightElement
-          paddingRight={8}
-          onClick={() => {
-            setSearchValue('');
-          }}
-        >
-          <CloseIcon color="gray.400" />
-        </InputRightElement>
-      </InputGroup>
-    </Box>
+      <InputRightElement
+        paddingRight={8}
+        onClick={() => {
+          setSearchValue('');
+        }}
+      >
+        <CloseIcon color="gray.400" />
+      </InputRightElement>
+    </InputGroup>
   );
 };
 

--- a/frontend/src/components/tables/DataTableSelectFilter.tsx
+++ b/frontend/src/components/tables/DataTableSelectFilter.tsx
@@ -1,0 +1,42 @@
+import { Select } from '@chakra-ui/react';
+import { type Column, type ColumnMeta } from '@tanstack/react-table';
+import React from 'react';
+
+interface DataTableSelectFilterColMeta<T, V> extends ColumnMeta<T, V> {
+  /* The options to filter from, if not defined will be taken from row values */
+  selectFilterOptions?: string[];
+  selectOptionPrefix?: string;
+}
+
+interface DataTableSelectFilterProps<T> {
+  column: Column<T>;
+}
+
+const DataTableSelectFilter = <T extends object>({
+  column: { getFilterValue, setFilterValue, id, columnDef },
+}: DataTableSelectFilterProps<T>): JSX.Element => {
+  const meta = columnDef.meta as DataTableSelectFilterColMeta<T, unknown> | undefined;
+  const filterValue = getFilterValue() as string[] | undefined;
+  const options = meta?.selectFilterOptions ?? [];
+
+  return (
+    <>
+      <Select
+        value={filterValue}
+        onChange={(e) => {
+          setFilterValue(e.target.value ?? undefined);
+        }}
+        minWidth="fit-content"
+      >
+        <option value="">{`${meta?.selectOptionPrefix ?? id}: All`}</option>
+        {options?.map((option, i) => (
+          <option key={i} value={option}>
+            {`${meta?.selectOptionPrefix ?? id}: ${option}`}
+          </option>
+        ))}
+      </Select>
+    </>
+  );
+};
+
+export default DataTableSelectFilter;

--- a/frontend/src/pages/questions/Questions.tsx
+++ b/frontend/src/pages/questions/Questions.tsx
@@ -1,5 +1,5 @@
 import DataTable from '../../components/tables/DataTable';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import QuestionsAPI from '../../api/questions/questions';
 import IconWithText from '../../components/content/IconWithText';
 import { BiSolidBook } from 'react-icons/bi';
@@ -11,7 +11,7 @@ import { AddIcon } from '@chakra-ui/icons';
 
 const Questions: React.FC = () => {
   const columnHelper = createColumnHelper<QuestionDataRowData>();
-  const questionColumns: Array<ColumnDef<QuestionDataRowData>> = useMemo(() => QuestionsTableColumns(columnHelper), []);
+  const questionColumns: Array<ColumnDef<QuestionDataRowData>> = QuestionsTableColumns(columnHelper);
   const [questionList, setQuestionList] = useState<QuestionDataRowData[]>();
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 

--- a/frontend/src/utils/questions.tsx
+++ b/frontend/src/utils/questions.tsx
@@ -1,9 +1,10 @@
 import { type ColumnDef, type ColumnHelper } from '@tanstack/react-table';
-import { type QuestionData } from '../types/questions/questions';
+import { QuestionComplexityEnum, type QuestionData } from '../types/questions/questions';
 import { Stack, Tag, Wrap, WrapItem } from '@chakra-ui/react';
 import QuestionComplexityTag from '../components/questions/QuestionComplexityTag';
 import QuestionViewIconButton from '../components/questions/QuestionViewIconButton';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import QuestionsAPI from '../api/questions/questions';
 
 export interface QuestionDataRowData extends QuestionData {
   action?: undefined;
@@ -12,6 +13,16 @@ export interface QuestionDataRowData extends QuestionData {
 export const QuestionsTableColumns = (
   columnHelper: ColumnHelper<QuestionDataRowData>,
 ): Array<ColumnDef<QuestionDataRowData>> => {
+  const [categories, setAllCategories] = useState<string[]>([]);
+  useEffect(() => {
+    new QuestionsAPI()
+      .getCategories()
+      .then((categories) => {
+        setAllCategories(categories);
+      })
+      .catch(console.error);
+  }, []);
+
   return [
     columnHelper.accessor('questionID', {
       cell: (id): number => id.getValue(),
@@ -22,7 +33,12 @@ export const QuestionsTableColumns = (
       header: 'Title',
     }),
     columnHelper.accessor('categories', {
+      meta: {
+        selectFilterOptions: categories,
+        selectOptionPrefix: 'Category',
+      },
       header: 'Categories',
+      filterFn: 'arrIncludes',
       enableColumnFilter: true,
       cell: (categories) => (
         <Stack direction="row" spacing={4}>
@@ -37,6 +53,10 @@ export const QuestionsTableColumns = (
       ),
     }),
     columnHelper.accessor('complexity', {
+      meta: {
+        selectFilterOptions: Object.values(QuestionComplexityEnum),
+        selectOptionPrefix: 'Complexity',
+      },
       header: 'Complexity',
       cell: (complexity) => <QuestionComplexityTag questionComplexity={complexity.getValue()} />,
     }),


### PR DESCRIPTION

Adds filtering to the table (for complexity/ category, but is extensible to removal/ addition of other columns). Only single select is currently supported as there is no native chakra multi-select component. :"(

https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/79991214/30a457f7-0725-40d2-a193-284b6f522cb8
