### PR TITLE
feat: attempt the multi select filter

### DIFF
--- a/frontend/src/components/questions/QuestionCategoryAutocomplete.tsx
+++ b/frontend/src/components/questions/QuestionCategoryAutocomplete.tsx
@@ -1,0 +1,65 @@
+import {
+  AutoComplete,
+  AutoCompleteInput,
+  AutoCompleteItem,
+  AutoCompleteList,
+  AutoCompleteTag,
+} from '@choc-ui/chakra-autocomplete';
+import React, { useEffect, useState } from 'react';
+import QuestionsAPI from '../../api/questions/questions';
+
+interface QuestionCategoryAutocompleteProps {
+  categories: string[];
+  handleChange: (categories: string[]) => void;
+  showTags: boolean;
+}
+
+const QuestionCategoryAutocomplete = ({
+  categories,
+  handleChange,
+  showTags,
+}: QuestionCategoryAutocompleteProps): JSX.Element => {
+  const [allCategories, setAllCategories] = useState<string[]>([]);
+  useEffect(() => {
+    new QuestionsAPI()
+      .getCategories()
+      .then((categories) => {
+        setAllCategories(categories);
+      })
+      .catch(console.error);
+  }, []);
+
+  return (
+    <AutoComplete
+      openOnFocus
+      closeOnSelect
+      closeOnBlur
+      multiple
+      value={categories}
+      onChange={(categories) => {
+        handleChange(categories as string[]);
+      }}
+      isLoading={allCategories.length === 0}
+    >
+      <AutoCompleteInput variant="filled">
+        {showTags &&
+          (({ tags }) =>
+            tags.map((tag, tid) => <AutoCompleteTag key={tid} label={tag.label as string} onRemove={tag.onRemove} />))}
+      </AutoCompleteInput>
+      <AutoCompleteList>
+        {allCategories.map((category, cid) => (
+          <AutoCompleteItem
+            key={`option-${cid}`}
+            value={category}
+            _selected={{ bg: 'whiteAlpha.50' }}
+            _focus={{ bg: 'whiteAlpha.100' }}
+          >
+            {category}
+          </AutoCompleteItem>
+        ))}
+      </AutoCompleteList>
+    </AutoComplete>
+  );
+};
+
+export default QuestionCategoryAutocomplete;

--- a/frontend/src/components/tables/DataTableSelectFilter.tsx
+++ b/frontend/src/components/tables/DataTableSelectFilter.tsx
@@ -1,19 +1,45 @@
-import { type Column } from '@tanstack/react-table';
+import { type ColumnMeta, type Column } from '@tanstack/react-table';
 import QuestionCategoryAutocomplete from '../questions/QuestionCategoryAutocomplete';
 import React from 'react';
+import { Select } from '@chakra-ui/react';
 
 interface DataTableSelectFilterProps<T> {
   column: Column<T>;
 }
 
+interface DataTableSelectFilterColMeta<T, V> extends ColumnMeta<T, V> {
+  /* The options to filter from, if not defined will be taken from row values */
+  selectFilterOptions?: string[];
+  selectOptionPrefix?: string;
+}
+
 const DataTableSelectFilter = <T extends object>({
-  column: { getFilterValue, setFilterValue },
+  column: { getFilterValue, setFilterValue, id, columnDef },
 }: DataTableSelectFilterProps<T>): JSX.Element => {
+  const meta = columnDef.meta as DataTableSelectFilterColMeta<T, unknown> | undefined;
   const filterValue = getFilterValue() as string[] | undefined;
+  const options = meta?.selectFilterOptions ?? [];
 
   return (
     <>
-      <QuestionCategoryAutocomplete handleChange={setFilterValue} categories={filterValue ?? []} showTags={false} />
+      {meta?.selectOptionPrefix === 'Category' ? (
+        <QuestionCategoryAutocomplete handleChange={setFilterValue} categories={filterValue ?? []} showTags={false} />
+      ) : (
+        <Select
+          value={filterValue}
+          onChange={(e) => {
+            setFilterValue(e.target.value ?? undefined);
+          }}
+          minWidth="fit-content"
+        >
+          <option value="">{`${meta?.selectOptionPrefix ?? id}: All`}</option>
+          {options?.map((option, i) => (
+            <option key={i} value={option}>
+              {`${meta?.selectOptionPrefix ?? id}: ${option}`}
+            </option>
+          ))}
+        </Select>
+      )}
     </>
   );
 };

--- a/frontend/src/components/tables/DataTableSelectFilter.tsx
+++ b/frontend/src/components/tables/DataTableSelectFilter.tsx
@@ -1,40 +1,19 @@
-import { Select } from '@chakra-ui/react';
-import { type Column, type ColumnMeta } from '@tanstack/react-table';
+import { type Column } from '@tanstack/react-table';
+import QuestionCategoryAutocomplete from '../questions/QuestionCategoryAutocomplete';
 import React from 'react';
-
-interface DataTableSelectFilterColMeta<T, V> extends ColumnMeta<T, V> {
-  /* The options to filter from, if not defined will be taken from row values */
-  selectFilterOptions?: string[];
-  selectOptionPrefix?: string;
-}
 
 interface DataTableSelectFilterProps<T> {
   column: Column<T>;
 }
 
 const DataTableSelectFilter = <T extends object>({
-  column: { getFilterValue, setFilterValue, id, columnDef },
+  column: { getFilterValue, setFilterValue },
 }: DataTableSelectFilterProps<T>): JSX.Element => {
-  const meta = columnDef.meta as DataTableSelectFilterColMeta<T, unknown> | undefined;
   const filterValue = getFilterValue() as string[] | undefined;
-  const options = meta?.selectFilterOptions ?? [];
 
   return (
     <>
-      <Select
-        value={filterValue}
-        onChange={(e) => {
-          setFilterValue(e.target.value ?? undefined);
-        }}
-        minWidth="fit-content"
-      >
-        <option value="">{`${meta?.selectOptionPrefix ?? id}: All`}</option>
-        {options?.map((option, i) => (
-          <option key={i} value={option}>
-            {`${meta?.selectOptionPrefix ?? id}: ${option}`}
-          </option>
-        ))}
-      </Select>
+      <QuestionCategoryAutocomplete handleChange={setFilterValue} categories={filterValue ?? []} showTags={false} />
     </>
   );
 };

--- a/frontend/src/pages/questions/CreateQuestion.tsx
+++ b/frontend/src/pages/questions/CreateQuestion.tsx
@@ -12,18 +12,12 @@ import {
   Textarea,
   useToast,
 } from '@chakra-ui/react';
-import {
-  AutoComplete,
-  AutoCompleteInput,
-  AutoCompleteItem,
-  AutoCompleteList,
-  AutoCompleteTag,
-} from '@choc-ui/chakra-autocomplete';
 
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import QuestionsAPI from '../../api/questions/questions';
 import { useNavigate } from 'react-router-dom';
 import { type AxiosError } from 'axios';
+import QuestionCategoryAutocomplete from '../../components/questions/QuestionCategoryAutocomplete';
 
 export const CreateQuestion: React.FC = () => {
   const [title, setTitle] = useState('');
@@ -31,22 +25,12 @@ export const CreateQuestion: React.FC = () => {
   const [categories, setCategories] = useState<string[]>([]);
   const [complexity, setComplexity] = useState('Easy');
   const [linkToQuestion, setLinkToQuestion] = useState('');
-  const [allCategories, setAllCategories] = useState<string[]>([]);
 
   const toast = useToast();
 
   const linkPrefix = 'https://leetcode.com/problems/';
 
   const navigate = useNavigate();
-
-  useEffect(() => {
-    new QuestionsAPI()
-      .getCategories()
-      .then((categories) => {
-        setAllCategories(categories);
-      })
-      .catch(console.error);
-  }, []);
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -102,36 +86,7 @@ export const CreateQuestion: React.FC = () => {
           </FormControl>
           <FormControl isRequired>
             <FormLabel>Categories</FormLabel>
-            <AutoComplete
-              openOnFocus
-              closeOnSelect
-              closeOnBlur
-              multiple
-              onChange={(categories) => {
-                setCategories(categories as string[]);
-              }}
-              isLoading={allCategories.length === 0}
-            >
-              <AutoCompleteInput variant="filled">
-                {({ tags }) =>
-                  tags.map((tag, tid) => (
-                    <AutoCompleteTag key={tid} label={tag.label as string} onRemove={tag.onRemove} />
-                  ))
-                }
-              </AutoCompleteInput>
-              <AutoCompleteList>
-                {allCategories.map((category, cid) => (
-                  <AutoCompleteItem
-                    key={`option-${cid}`}
-                    value={category}
-                    _selected={{ bg: 'whiteAlpha.50' }}
-                    _focus={{ bg: 'whiteAlpha.100' }}
-                  >
-                    {category}
-                  </AutoCompleteItem>
-                ))}
-              </AutoCompleteList>
-            </AutoComplete>
+            <QuestionCategoryAutocomplete categories={categories} handleChange={setCategories} showTags={true} />
           </FormControl>
           <FormControl isRequired>
             <FormLabel>Complexity</FormLabel>

--- a/frontend/src/utils/questions.tsx
+++ b/frontend/src/utils/questions.tsx
@@ -38,7 +38,7 @@ export const QuestionsTableColumns = (
         selectOptionPrefix: 'Category',
       },
       header: 'Categories',
-      filterFn: 'arrIncludes',
+      filterFn: 'arrIncludesAll',
       enableColumnFilter: true,
       cell: (categories) => (
         <Stack direction="row" spacing={4}>


### PR DESCRIPTION
refactor and extract out multi-select filter for reuse by index page

![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/34371483/87e2c5f1-d453-4d3a-b2b8-0a87919b3d4f)
e.g. filter by 2 tags

**problem: i am stuck trying to get the filters back from react table to add tags back below the filters :[**

~~wait i broke the other filter 🤡~~ fixed in a ugly way

related to #26