### PR TITLE
[frontend] fix: complexity table sorting

### DIFF
--- a/frontend/src/types/questions/questions.ts
+++ b/frontend/src/types/questions/questions.ts
@@ -4,6 +4,12 @@ export enum QuestionComplexityEnum {
   HARD = 'Hard',
 }
 
+export const QuestionComplexityEnumToLevelMap: Record<QuestionComplexityEnum, number> = Object.freeze({
+  [QuestionComplexityEnum.EASY]: 1,
+  [QuestionComplexityEnum.MEDIUM]: 2,
+  [QuestionComplexityEnum.HARD]: 3,
+});
+
 export interface QuestionData {
   questionID: number;
   title: string;

--- a/frontend/src/utils/questions.tsx
+++ b/frontend/src/utils/questions.tsx
@@ -1,5 +1,9 @@
-import { type ColumnDef, type ColumnHelper } from '@tanstack/react-table';
-import { QuestionComplexityEnum, type QuestionData } from '../types/questions/questions';
+import { type SortingFn, type ColumnDef, type ColumnHelper, type Row } from '@tanstack/react-table';
+import {
+  QuestionComplexityEnum,
+  QuestionComplexityEnumToLevelMap,
+  type QuestionData,
+} from '../types/questions/questions';
 import { Stack, Tag, Wrap, WrapItem } from '@chakra-ui/react';
 import QuestionComplexityTag from '../components/questions/QuestionComplexityTag';
 import QuestionViewIconButton from '../components/questions/QuestionViewIconButton';
@@ -9,6 +13,18 @@ import QuestionsAPI from '../api/questions/questions';
 export interface QuestionDataRowData extends QuestionData {
   action?: undefined;
 }
+
+export const ComplexitySortingFn: SortingFn<QuestionData> = (
+  rowA: Row<QuestionData>,
+  rowB: Row<QuestionData>,
+  _columnId: string,
+): number => {
+  const rowAComplexity: QuestionComplexityEnum = rowA.getValue('complexity');
+  const rowBComplexity: QuestionComplexityEnum = rowB.getValue('complexity');
+  const rowAComplexityLevel: number = QuestionComplexityEnumToLevelMap[rowAComplexity];
+  const rowBComplexityLevel: number = QuestionComplexityEnumToLevelMap[rowBComplexity];
+  return rowAComplexityLevel > rowBComplexityLevel ? 1 : rowAComplexityLevel < rowBComplexityLevel ? -1 : 0;
+};
 
 export const QuestionsTableColumns = (
   columnHelper: ColumnHelper<QuestionDataRowData>,
@@ -57,6 +73,7 @@ export const QuestionsTableColumns = (
         selectFilterOptions: Object.values(QuestionComplexityEnum),
         selectOptionPrefix: 'Complexity',
       },
+      sortingFn: ComplexitySortingFn,
       header: 'Complexity',
       cell: (complexity) => <QuestionComplexityTag questionComplexity={complexity.getValue()} />,
     }),


### PR DESCRIPTION
Sorting now fixed in 'natural' complexity order (Easy < Medium < Hard)

| Ascending Complexity | Descending Complexity |
| -----------------------|-------------------------|
|<img width="1323" alt="Screenshot 2023-09-13 at 8 55 45 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/79991214/4cd87413-d4f7-4566-8d12-9b3e80156972"> |<img width="1341" alt="Screenshot 2023-09-13 at 8 55 52 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/79991214/a562eba5-2c0b-42b4-bb5f-a4b8116c4bc8"> |

Fixes https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/issues/48