### PR TITLE
[frontend] feat: add 404 page

### DIFF
--- a/frontend/src/pages/routing/AuthenticatedApp.tsx
+++ b/frontend/src/pages/routing/AuthenticatedApp.tsx
@@ -4,14 +4,16 @@ import { CreateQuestion } from '../questions/CreateQuestion';
 import Questions from '../questions/Questions';
 import { UpdateQuestion } from '../questions/UpdateQuestion';
 import ViewQuestion from '../questions/ViewQuestion';
+import PageNotFound from './NotFound';
 
 const AuthenticatedApp: React.FC = () => {
   return (
     <Routes>
-      <Route path="questions/new" element={<CreateQuestion />} />
       <Route path="/" element={<Questions />} />
+      <Route path="questions/new" element={<CreateQuestion />} />
       <Route path="question/:questionId/edit" element={<UpdateQuestion />} />
       <Route path="/question/:questionId" element={<ViewQuestion />} />
+      <Route path="*" element={<PageNotFound />} />
     </Routes>
   );
 };

--- a/frontend/src/pages/routing/NotFound.tsx
+++ b/frontend/src/pages/routing/NotFound.tsx
@@ -1,0 +1,35 @@
+import { Heading, Link as ExternalLink, Text, Button, useColorModeValue, Stack } from '@chakra-ui/react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { PEERPREP_GITHUB_ISSUES_LINK } from '../../utils/constants';
+
+const PageNotFound: React.FC = () => {
+  return (
+    <Stack alignItems="center" marginTop={10}>
+      <Heading fontSize={{ base: '7xl', md: '9xl' }} marginBottom={4} color="gray.500">
+        {'< 404 />'}
+      </Heading>
+      <Heading fontSize="4xl">{"Uh oh. We can't find the page you're looking for..."}</Heading>
+      <Text fontSize="xl" color={useColorModeValue('gray.500', 'gray.300')}>
+        {"Yikes, the page you're looking for might be deleted or might not exist."}
+      </Text>
+
+      <Stack direction="row" marginTop={4} spacing={6}>
+        <Button
+          colorScheme="teal"
+          variant="outline"
+          as={ExternalLink}
+          isExternal
+          href={`${PEERPREP_GITHUB_ISSUES_LINK}/new`}
+        >
+          Report an issue
+        </Button>
+        <Link to="/">
+          <Button colorScheme="teal">Bring me back home</Button>
+        </Link>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default PageNotFound;

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,0 +1,2 @@
+export const PEERPREP_GITHUB_LINK = 'https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17';
+export const PEERPREP_GITHUB_ISSUES_LINK = `${PEERPREP_GITHUB_LINK}/issues`;


### PR DESCRIPTION
Adds 404 page that users will be redirected to when page does not exist.

("Report an Issue" currently redirects to https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/issues/new, can change or remove if not needed)

<img width="1438" alt="Screenshot 2023-09-20 at 6 03 53 AM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/79991214/06e0ce96-e4e9-4ebd-9898-a2d54da988bb">
<br /><br />
<img width="1422" alt="Screenshot 2023-09-20 at 6 08 17 AM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/79991214/d6bd5611-662d-414a-b337-ceda0f001934">
