### PR TITLE
feat: add docker-compose

### DIFF
--- a/backend/user-service/.gitignore
+++ b/backend/user-service/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 # Keep environment variables out of version control
-.env
+.env*

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:18
+
+RUN npm install -g nodemon
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+RUN npx prisma generate
+
+ENV PORT=8000
+
+EXPOSE 8000
+
+CMD ["npm", "start"]
+

--- a/backend/user-service/package-lock.json
+++ b/backend/user-service/package-lock.json
@@ -14,14 +14,22 @@
         "@types/jsonwebtoken": "^9.0.3",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-async-handler": "^1.2.0",
+        "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
+        "morgan": "^1.10.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.4",
+        "@types/cors": "^2.8.14",
         "@types/express": "^4.17.17",
+        "@types/express-validator": "^3.0.0",
+        "@types/morgan": "^1.9.5",
         "nodemon": "^3.0.1",
         "prisma": "^5.3.1",
         "ts-node": "^10.9.1",
@@ -154,6 +162,15 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.14",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.14.tgz",
+      "integrity": "sha512-RXHUvNWYICtbP6s18PnOCaqToK8y14DnLd75c6HfyKf228dxy7pHNOQkxPtvXKp/hINFMDjbYzsj63nnpPMSRQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
@@ -178,6 +195,16 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/express-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/express-validator/-/express-validator-3.0.0.tgz",
+      "integrity": "sha512-LusnB0YhTXpBT25PXyGPQlK7leE1e41Vezq1hHEUwjfkopM1Pkv2X2Ppxqh9c+w/HZ6Udzki8AJotKNjDTGdkQ==",
+      "deprecated": "This is a stub types definition for express-validator (https://github.com/ctavan/express-validator). express-validator provides its own type definitions, so you don't need @types/express-validator installed!",
+      "dev": true,
+      "dependencies": {
+        "express-validator": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
@@ -197,6 +224,15 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.5.tgz",
+      "integrity": "sha512-5TgfIWm0lcTGnbCZExwc19dCOMOMmAiiBZQj8Ko3NRxsVDgRxf+AEGRQTqNVA5Yh2xfdWp4clbAEMbYP+jkOqg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.6.1",
@@ -304,6 +340,22 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/bcryptjs": {
       "version": "2.4.3",
@@ -474,6 +526,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -512,6 +576,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/ecdsa-sig-formatter": {
@@ -587,6 +662,23 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+    },
+    "node_modules/express-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.0.1.tgz",
+      "integrity": "sha512-oB+z9QOzQIE8FnlINqyIFA8eIckahC6qc8KtqLdLJcU3/phVyuhXH3bA4qzcrhme+1RYaCSwrq+TlZ/kAKIARA==",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "^13.9.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -858,6 +950,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -984,6 +1081,32 @@
         "node": "*"
       }
     },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/morgan/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1087,6 +1210,14 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1489,6 +1620,14 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -14,7 +14,10 @@
   "license": "ISC",
   "devDependencies": {
     "@types/cookie-parser": "^1.4.4",
+    "@types/cors": "^2.8.14",
     "@types/express": "^4.17.17",
+    "@types/express-validator": "^3.0.0",
+    "@types/morgan": "^1.9.5",
     "nodemon": "^3.0.1",
     "prisma": "^5.3.1",
     "ts-node": "^10.9.1",
@@ -26,8 +29,13 @@
     "@types/jsonwebtoken": "^9.0.3",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-async-handler": "^1.2.0",
+    "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/backend/user-service/src/models/prisma/schema.prisma
+++ b/backend/user-service/src/models/prisma/schema.prisma
@@ -3,6 +3,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {

--- a/backend/user-service/src/models/prisma/seed.ts
+++ b/backend/user-service/src/models/prisma/seed.ts
@@ -4,6 +4,10 @@ import { hashPassword } from "../../utils/auth";
 async function seed() {
   try {
     // Seed the User and Language tables
+    await prisma.userLanguage.deleteMany();
+    await prisma.user.deleteMany();
+    await prisma.language.deleteMany();
+
     const user1 = await prisma.user.create({
       data: {
         username: "admin_user",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+services:
+  question-service:
+    build: ./backend/question-service
+    ports:
+      - 8080:8080
+    volumes:
+      - ./backend/question-service:/usr/src/app
+
+  frontend:
+    build: ./frontend
+    volumes:
+      - ./frontend:/app
+    ports:
+      - 3000:3000
+    env_file: ./frontend/.env
+
+  user-service:
+    build: ./backend/user-service
+    ports:
+      - 8000:8000
+    volumes:
+      - ./backend/user-service:/usr/src/app
+    depends_on:
+      - postgres
+    env_file: ./backend/user-service/.env.docker
+
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: peerprep
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 1m30s
+    ports:
+      - 5432:5432
+
+  migration:
+    build: ./backend/user-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command:
+      [
+        "npx",
+        "prisma",
+        "db",
+        "push",
+        ";",
+        "npm",
+        "run",
+        "seed"
+      ]
+    env_file: ./backend/user-service/.env.docker
+
+# https://medium.com/@sumankpaul/run-db-migration-script-in-docker-compose-ce8e447a77ba

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "start"]
+


### PR DESCRIPTION
also dockerise user service

## setup:
- get user-service/.env.docker from notion
- `docker-compose up --build` instead of `npm start` x 3


## notes
- the volumes in docker-compose is so the changes in your local env are reflected in the docker container to make it easier for development [this probably is not good for prod]

- note about `npx prisma studio`
  - the backend accesses the db via `postgres:5432`, because `postgres` is the container name and thus the hostname used inside the docker network. (but you are not inside the container, so you can run....)

  -  `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/peerprep?schema=public" npx prisma studio`

  - i cant seem to get the seed to run but the db tables are there