### PR TITLE
frontend: auth + other misc fixes

### DIFF
--- a/backend/question-service/src/controllers/questions.ts
+++ b/backend/question-service/src/controllers/questions.ts
@@ -161,10 +161,6 @@ export const updateQuestion: RequestHandler[] = [
 
     const sameQuestionExists = await QuestionModel.exists({
       title: formData.title,
-      categories: formData.categories,
-      complexity: formData.complexity,
-      linkToQuestion: formData.linkToQuestion,
-      questionDescription: formData.questionDescription,
     });
 
     if (sameQuestionExists) {
@@ -178,7 +174,7 @@ export const updateQuestion: RequestHandler[] = [
     const finalQuestion = await QuestionModel.findByIdAndUpdate(
       existingQuestion._id,
       formData,
-      { new: true },
+      { new: true }
     );
 
     res.status(200).json({ data: finalQuestion, status: "success" });

--- a/backend/user-service/src/controllers/authController.ts
+++ b/backend/user-service/src/controllers/authController.ts
@@ -137,6 +137,7 @@ export const logIn: RequestHandler[] = [
       });
 
       return res.status(200).json({
+        user: userWithoutPassword,
         message: `${userWithoutPassword.username} has been authenticated`,
         accessToken,
         refreshToken,
@@ -181,13 +182,11 @@ export async function updateBothTokens(req: Request, res: Response) {
       const decoded = await authenticateRefreshToken(refreshToken);
 
       if (!storedRefreshTokens.includes(refreshToken)) {
-        res
-          .status(401)
-          .json({
-            errors: [
-              { msg: "Not authorized, refresh token not found in server" },
-            ],
-          });
+        res.status(401).json({
+          errors: [
+            { msg: "Not authorized, refresh token not found in server" },
+          ],
+        });
       } else {
         const payload = decoded as JwtPayload;
         const userId = payload.user.id;
@@ -245,13 +244,11 @@ export async function updateAccessToken(req: Request, res: Response) {
       const decoded = await authenticateRefreshToken(refreshToken);
 
       if (!storedRefreshTokens.includes(refreshToken)) {
-        res
-          .status(401)
-          .json({
-            errors: [
-              { msg: "Not authorized, refresh token not found in server" },
-            ],
-          });
+        res.status(401).json({
+          errors: [
+            { msg: "Not authorized, refresh token not found in server" },
+          ],
+        });
       } else {
         const payload = decoded as JwtPayload;
         const userWithoutPassword = payload.user;

--- a/frontend/src/api/users/auth.ts
+++ b/frontend/src/api/users/auth.ts
@@ -24,4 +24,8 @@ export default class AuthAPI {
     const response = await userServiceClient.get(this.getAuthUrl() + 'currentUser');
     return response.data.user;
   }
+
+  public async useRefreshToken(): Promise<never> {
+    return await userServiceClient.get(this.getAuthUrl() + 'token');
+  }
 }

--- a/frontend/src/pages/questions/Questions.tsx
+++ b/frontend/src/pages/questions/Questions.tsx
@@ -8,6 +8,8 @@ import { type ColumnDef, createColumnHelper, type Column } from '@tanstack/react
 import { type QuestionDataRowData, QuestionsTableColumns } from '../../utils/questions';
 import { Link } from 'react-router-dom';
 import { AddIcon } from '@chakra-ui/icons';
+import { useSelector } from 'react-redux';
+import { selectIsAdmin } from '../../reducers/authSlice';
 
 const Questions: React.FC = () => {
   const columnHelper = createColumnHelper<QuestionDataRowData>();
@@ -15,6 +17,7 @@ const Questions: React.FC = () => {
   // Pass setQuestionList as a prop to the QuestionsTableColumns function
   const questionColumns: Array<ColumnDef<QuestionDataRowData>> = QuestionsTableColumns(columnHelper, setQuestionList);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const isAdmin = useSelector(selectIsAdmin);
 
   useEffect(() => {
     if (!isLoaded) {
@@ -34,11 +37,13 @@ const Questions: React.FC = () => {
     <Stack paddingX={16} paddingY={8} spacing={6}>
       <Flex justifyContent={'space-between'}>
         <IconWithText fontSize="lg" fontWeight="bold" text="Question Repository" icon={<BiSolidBook size={20} />} />
-        <Link to="/questions/new">
-          <Button leftIcon={<AddIcon />} colorScheme="teal">
-            New Question
-          </Button>
-        </Link>
+        {isAdmin && (
+          <Link to="/questions/new">
+            <Button leftIcon={<AddIcon />} colorScheme="teal">
+              New Question
+            </Button>
+          </Link>
+        )}
       </Flex>
       <Skeleton isLoaded={isLoaded}>
         {questionList !== undefined && (

--- a/frontend/src/pages/questions/UpdateQuestion.tsx
+++ b/frontend/src/pages/questions/UpdateQuestion.tsx
@@ -5,7 +5,6 @@ import QuestionForm from '../../components/content/QuestionForm';
 import { LINK_PREFIX, type QuestionPostData, type QuestionData } from '../../types/questions/questions';
 
 export const UpdateQuestion: React.FC = () => {
-  console.log('huh?');
   const { questionId } = useParams();
   const navigate = useNavigate();
 

--- a/frontend/src/pages/questions/UpdateQuestion.tsx
+++ b/frontend/src/pages/questions/UpdateQuestion.tsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import QuestionsAPI from '../../api/questions/questions';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import QuestionForm from '../../components/content/QuestionForm';
 import { LINK_PREFIX, type QuestionPostData, type QuestionData } from '../../types/questions/questions';
 
 export const UpdateQuestion: React.FC = () => {
+  console.log('huh?');
   const { questionId } = useParams();
+  const navigate = useNavigate();
+
   let questionIdString: string;
   if (questionId !== undefined) {
     questionIdString = questionId;
@@ -25,6 +28,7 @@ export const UpdateQuestion: React.FC = () => {
       })
       .catch((error) => {
         console.error('Error fetching question data:', error);
+        navigate('/404');
         setDataLoaded(true);
       });
   }, []);

--- a/frontend/src/pages/questions/ViewQuestion.tsx
+++ b/frontend/src/pages/questions/ViewQuestion.tsx
@@ -71,7 +71,7 @@ const ViewQuestion: React.FC = () => {
               <Link href={question.linkToQuestion}>{question.linkToQuestion}</Link>
             </Text>
             <Divider mt={4} />
-            <Box ml="8px">
+            <Box ml="8px" minWidth={'80%'}>
               <VStack align="start" spacing={4} mt={4}>
                 <Heading as="h2" size="md">
                   Description

--- a/frontend/src/pages/questions/ViewQuestion.tsx
+++ b/frontend/src/pages/questions/ViewQuestion.tsx
@@ -9,12 +9,15 @@ import CodeEditor from '../../components/code/CodeEditor';
 import { Allotment } from 'allotment';
 import 'allotment/dist/style.css';
 import QuestionEditIconButton from '../../components/questions/QuestionEditIconButton';
+import { selectIsAdmin } from '../../reducers/authSlice';
+import { useSelector } from 'react-redux';
 
 const ViewQuestion: React.FC = () => {
   const { questionId } = useParams();
   const [question, setQuestion] = useState<QuestionData | null>(null);
   const colourScheme = useColorModeValue('gray.600', 'gray.400');
   const editorTheme = useColorModeValue('light', 'vs-dark');
+  const isAdmin = useSelector(selectIsAdmin);
 
   useEffect(() => {
     const fetchQuestion = async (): Promise<void> => {
@@ -54,7 +57,7 @@ const ViewQuestion: React.FC = () => {
           <VStack as="div" style={{ overflowY: 'auto', height: '100%', padding: '16px' }}>
             <Heading as="h1" size="xl" textAlign="center">
               {question.title}
-              <QuestionEditIconButton questionId={question.questionID} title={question.title} />
+              {isAdmin && <QuestionEditIconButton questionId={question.questionID} title={question.title} />}
             </Heading>
             <Text fontSize="md" color={colourScheme} mt={2}>
               <span style={{ fontWeight: 'bold' }}>Complexity: </span>
@@ -67,23 +70,6 @@ const ViewQuestion: React.FC = () => {
               <span style={{ fontWeight: 'bold' }}>Link to Question: </span>
               <Link href={question.linkToQuestion}>{question.linkToQuestion}</Link>
             </Text>
-            <Divider mt={4} />
-            <VStack align="start" spacing={4} mt={4}>
-              <Heading as="h2" size="md">
-                Description
-              </Heading>
-              <Text fontSize="md" color={colourScheme} mt={2}>
-                <span style={{ fontWeight: 'bold' }}>Complexity: </span>
-                <QuestionComplexityTag questionComplexity={question.complexity} />
-              </Text>
-              <Text fontSize="md" color={colourScheme} mt={2}>
-                <span style={{ fontWeight: 'bold' }}>Categories:</span> {question.categories.join(', ')}
-              </Text>
-              <Text fontSize="md" color={colourScheme} mt={2}>
-                <span style={{ fontWeight: 'bold' }}>Link to Question: </span>
-                <Link href={question.linkToQuestion}>{question.linkToQuestion}</Link>
-              </Text>
-            </VStack>
             <Divider mt={4} />
             <Box ml="8px">
               <VStack align="start" spacing={4} mt={4}>

--- a/frontend/src/pages/questions/ViewQuestion.tsx
+++ b/frontend/src/pages/questions/ViewQuestion.tsx
@@ -1,6 +1,6 @@
 import { Box, Heading, Text, Link, VStack, Divider, useColorModeValue, Spinner, Center } from '@chakra-ui/react';
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import QuestionsAPI from '../../api/questions/questions';
 import { type QuestionData } from '../../types/questions/questions';
 import QuestionComplexityTag from '../../components/questions/QuestionComplexityTag';
@@ -18,12 +18,16 @@ const ViewQuestion: React.FC = () => {
   const colourScheme = useColorModeValue('gray.600', 'gray.400');
   const editorTheme = useColorModeValue('light', 'vs-dark');
   const isAdmin = useSelector(selectIsAdmin);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchQuestion = async (): Promise<void> => {
       try {
         if (questionId !== null && questionId !== undefined) {
           const response = await new QuestionsAPI().getQuestionById(parseInt(questionId, 10));
+          if (response == null) {
+            navigate('/404');
+          }
           setQuestion(response);
         }
       } catch (error) {

--- a/frontend/src/pages/routing/AppRouter.tsx
+++ b/frontend/src/pages/routing/AppRouter.tsx
@@ -1,24 +1,45 @@
+import { Center, Spinner } from '@chakra-ui/react';
 import AuthAPI from '../../api/users/auth';
 import { selectIsLoggedIn, setUser } from '../../reducers/authSlice';
 import { useAppDispatch, useAppSelector } from '../../reducers/hooks';
 import AuthenticatedApp from './AuthenticatedApp';
 import UnauthenticatedApp from './UnauthenticatedApp';
-import React from 'react';
+import React, { useState } from 'react';
 
 const AppRouter: React.FC = () => {
   const isLoggedIn = useAppSelector(selectIsLoggedIn);
   const dispatch = useAppDispatch();
-
+  const authApi = new AuthAPI();
+  const [loading, setLoading] = useState(true);
   if (!isLoggedIn) {
-    new AuthAPI()
+    authApi
       .getCurrentUser()
-      .then((user) => dispatch(setUser(user)))
+      .then((user) => {
+        dispatch(setUser(user));
+        setLoading(false);
+      })
       .catch((err) => {
-        // Possibly due to no token (not logged in yet)
-        console.error(err);
+        // Possibly due to no token (not logged in yet) / expired access token
+        console.log(err);
+        authApi
+          .useRefreshToken()
+          .then(async () => await authApi.getCurrentUser())
+          .then((user) => dispatch(setUser(user)))
+          .catch(() => 'User is currently unauthenticated.')
+          .finally(() => {
+            setLoading(false);
+          });
       });
   }
-  return isLoggedIn ? <AuthenticatedApp /> : <UnauthenticatedApp />;
+  return loading ? (
+    <Center h="100vh">
+      <Spinner size="xl" />
+    </Center>
+  ) : isLoggedIn ? (
+    <AuthenticatedApp />
+  ) : (
+    <UnauthenticatedApp />
+  );
 };
 
 export default AppRouter;

--- a/frontend/src/pages/routing/AuthenticatedApp.tsx
+++ b/frontend/src/pages/routing/AuthenticatedApp.tsx
@@ -5,14 +5,16 @@ import Questions from '../questions/Questions';
 import { UpdateQuestion } from '../questions/UpdateQuestion';
 import ViewQuestion from '../questions/ViewQuestion';
 import PageNotFound from './NotFound';
+import ProtectedRoute from './ProtectedRoute';
 
 const AuthenticatedApp: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<Questions />} />
-      <Route path="questions/new" element={<CreateQuestion />} />
-      <Route path="question/:questionId/edit" element={<UpdateQuestion />} />
+      <Route path="/questions/new" element={<ProtectedRoute child={<CreateQuestion />} />} />
       <Route path="/question/:questionId" element={<ViewQuestion />} />
+      <Route path="/question/:questionId/edit" element={<ProtectedRoute child={<UpdateQuestion />} />} />
+
       <Route path="*" element={<PageNotFound />} />
     </Routes>
   );

--- a/frontend/src/pages/routing/NotAuthorized.tsx
+++ b/frontend/src/pages/routing/NotAuthorized.tsx
@@ -1,0 +1,35 @@
+import { Heading, Link as ExternalLink, Text, Button, useColorModeValue, Stack } from '@chakra-ui/react';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { PEERPREP_GITHUB_ISSUES_LINK } from '../../utils/constants';
+
+const PageNotAuthorized: React.FC = () => {
+  return (
+    <Stack alignItems="center" marginTop={10}>
+      <Heading fontSize={{ base: '7xl', md: '9xl' }} marginBottom={4} color="gray.500">
+        {'< 403 />'}
+      </Heading>
+      <Heading fontSize="4xl">{'Uh oh. We found the page, but...'}</Heading>
+      <Text fontSize="xl" color={useColorModeValue('gray.500', 'gray.300')}>
+        {'You are not authorised to access it!'}
+      </Text>
+
+      <Stack direction="row" marginTop={4} spacing={6}>
+        <Button
+          colorScheme="teal"
+          variant="outline"
+          as={ExternalLink}
+          isExternal
+          href={`${PEERPREP_GITHUB_ISSUES_LINK}/new`}
+        >
+          Report an issue
+        </Button>
+        <Link to="/">
+          <Button colorScheme="teal">Bring me back home</Button>
+        </Link>
+      </Stack>
+    </Stack>
+  );
+};
+
+export default PageNotAuthorized;

--- a/frontend/src/pages/routing/ProtectedRoute.tsx
+++ b/frontend/src/pages/routing/ProtectedRoute.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { selectIsAdmin } from '../../reducers/authSlice';
+import PageNotAuthorized from './NotAuthorized';
+
+interface ProtectedRouteProps {
+  child: JSX.Element;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ child }) => {
+  const isAdmin = useSelector(selectIsAdmin);
+  return isAdmin ? child : <PageNotAuthorized />;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/pages/routing/UnauthenticatedApp.tsx
+++ b/frontend/src/pages/routing/UnauthenticatedApp.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import LoginForm from '../auth/LoginForm';
 import SignUpForm from '../auth/SignUpForm';
 
@@ -7,7 +7,8 @@ const UnauthenticatedApp: React.FC = () => {
   return (
     <Routes>
       <Route path="/signup" element={<SignUpForm />} />
-      <Route path="*" element={<LoginForm />} />
+      <Route path="/login" element={<LoginForm />} />
+      <Route path="*" element={<Navigate to="/login" />} />
     </Routes>
   );
 };

--- a/frontend/src/reducers/authSlice.ts
+++ b/frontend/src/reducers/authSlice.ts
@@ -28,5 +28,7 @@ export const { setUser, logOut } = counterSlice.actions;
 
 export const selectUser = (state: RootState): User | null => state.auth.user;
 export const selectIsLoggedIn = (state: RootState): boolean => state.auth.user !== null;
+export const selectIsAdmin = (state: RootState): boolean =>
+  state.auth.user !== null && state.auth.user.role === 'ADMIN';
 
 export default counterSlice.reducer;

--- a/frontend/src/utils/questions.tsx
+++ b/frontend/src/utils/questions.tsx
@@ -10,6 +10,8 @@ import QuestionViewIconButton from '../components/questions/QuestionViewIconButt
 import QuestionDeleteIconButton from '../components/questions/QuestionDeleteIconButton';
 import React, { useEffect, useState } from 'react';
 import QuestionsAPI from '../api/questions/questions';
+import { useSelector } from 'react-redux';
+import { selectIsAdmin } from '../reducers/authSlice';
 
 export interface QuestionDataRowData extends QuestionData {
   action?: undefined;
@@ -32,6 +34,8 @@ export const QuestionsTableColumns = (
   // Accept the setQuestionList prop
   setQuestionList: React.Dispatch<React.SetStateAction<QuestionDataRowData[]>>,
 ): Array<ColumnDef<QuestionDataRowData>> => {
+  const isAdmin = useSelector(selectIsAdmin);
+
   const [categories, setAllCategories] = useState<string[]>([]);
   useEffect(() => {
     new QuestionsAPI()
@@ -80,6 +84,7 @@ export const QuestionsTableColumns = (
       header: 'Complexity',
       cell: (complexity) => <QuestionComplexityTag questionComplexity={complexity.getValue()} />,
     }),
+
     columnHelper.accessor('action', {
       header: '',
       enableSorting: false,
@@ -87,13 +92,15 @@ export const QuestionsTableColumns = (
       cell: (cell) => (
         <Stack direction="row" spacing={2}>
           <QuestionViewIconButton questionId={cell.row.original.questionID} title={cell.row.original.title} />
-          <QuestionDeleteIconButton
-            questionId={cell.row.original.questionID}
-            onDelete={(questionId) => {
-              // Remove the deleted question from the list
-              setQuestionList((prevList) => prevList.filter((question) => question.questionID !== questionId));
-            }}
-          />
+          {isAdmin && (
+            <QuestionDeleteIconButton
+              questionId={cell.row.original.questionID}
+              onDelete={(questionId) => {
+                // Remove the deleted question from the list
+                setQuestionList((prevList) => prevList.filter((question) => question.questionID !== questionId));
+              }}
+            />
+          )}
         </Stack>
       ),
     }),


### PR DESCRIPTION
## things done

### auth related
- [x] [backend - user-service] send user over after login or frontend will crash on accessing question
- [x] render a 403 page ripped off the 404 page
- [x] conditionally hide create/edit/delete buttons if you arent an admin
- [x] /currentUser should attempt /token if it fails

### random stuff
- [x] remove duplicate description in viewquestion
- [x] redirect to 404 if question not found view/edit
- [x] give minWidth to ViewQuestion description or it looks a bit sus if the description is small
- [x] fix edit question duplicate check

## pr will not handle
- go chase every api call to attempt /token when unauthorised 