### PR TITLE
[backend] feat: add reset password

### DIFF
--- a/backend/user-service/package-lock.json
+++ b/backend/user-service/package-lock.json
@@ -21,6 +21,7 @@
         "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.0",
+        "nodemailer": "^6.9.5",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -30,6 +31,7 @@
         "@types/express": "^4.17.17",
         "@types/express-validator": "^3.0.0",
         "@types/morgan": "^1.9.5",
+        "@types/nodemailer": "^6.4.11",
         "nodemon": "^3.0.1",
         "prisma": "^5.3.1",
         "ts-node": "^10.9.1",
@@ -238,6 +240,15 @@
       "version": "20.6.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.1.tgz",
       "integrity": "sha512-4LcJvuXQlv4lTHnxwyHQZ3uR9Zw2j7m1C9DfuwoTFQQP4Pmu04O6IfLYgMmHoOCt0nosItLLZAH+sOrRE0Bo8g=="
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.11.tgz",
+      "integrity": "sha512-Ld2c0frwpGT4VseuoeboCXQ7UJIkK3X7Lx/4YsZEiUHtHsthWAOCYtf6PAiLhMtfwV0cWJRabLBS3+LD8x6Nrw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/qs": {
       "version": "6.9.8",
@@ -1118,6 +1129,14 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.5.tgz",
+      "integrity": "sha512-/dmdWo62XjumuLc5+AYQZeiRj+PRR8y8qKtFCOyuOl1k/hckZd8durUUHs/ucKx6/8kN+wFxqKJlQ/LK/qR5FA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -18,6 +18,7 @@
     "@types/express": "^4.17.17",
     "@types/express-validator": "^3.0.0",
     "@types/morgan": "^1.9.5",
+    "@types/nodemailer": "^6.4.11",
     "nodemon": "^3.0.1",
     "prisma": "^5.3.1",
     "ts-node": "^10.9.1",
@@ -36,6 +37,7 @@
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.0",
+    "nodemailer": "^6.9.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/backend/user-service/src/routes/authRoutes.ts
+++ b/backend/user-service/src/routes/authRoutes.ts
@@ -18,5 +18,7 @@ router.get(
   AuthMiddleWare.verifyAccessToken,
   AuthController.getCurrentUser,
 );
+router.post("/send-reset-email", AuthController.sendResetEmail);
+router.post("/reset-password", AuthController.resetPassword);
 
 export default router;

--- a/backend/user-service/src/utils/jwt.ts
+++ b/backend/user-service/src/utils/jwt.ts
@@ -2,6 +2,7 @@ import jwt from "jsonwebtoken";
 
 const ACCESS_TOKEN_SECRET = process.env.ACCESS_TOKEN_SECRET as string;
 const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET as string;
+const TEMPORARY_TOKEN_SECRET = process.env.TEMPORARY_TOKEN_SECRET as string;
 
 export async function generateAccessToken(userWithoutPassword: object) {
   return jwt.sign({ user: userWithoutPassword }, ACCESS_TOKEN_SECRET, {
@@ -47,4 +48,20 @@ export async function authenticateRefreshToken(
       },
     );
   });
+}
+
+// is using email or the entire object better
+export function generateTemporaryToken(email: string): string {
+  return jwt.sign({ email }, TEMPORARY_TOKEN_SECRET, { expiresIn: "1h" });
+}
+
+export function verifyTemporaryToken(token: string): { email: string } | null {
+  try {
+    const decoded = jwt.verify(token, TEMPORARY_TOKEN_SECRET) as {
+      email: string;
+    };
+    return decoded;
+  } catch (error) {
+    return null;
+  }
 }

--- a/backend/user-service/src/utils/nodemailer.ts
+++ b/backend/user-service/src/utils/nodemailer.ts
@@ -1,0 +1,12 @@
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  service: "gmail",
+  host: "smtp.gmail.com",
+  secure: false, 
+  auth: {
+    user: "peerprep17@gmail.com",
+    pass: "ztud otnc ixyt kfwo"
+  },
+});
+export default transporter;

--- a/backend/user-service/src/utils/nodemailer.ts
+++ b/backend/user-service/src/utils/nodemailer.ts
@@ -5,8 +5,8 @@ const transporter = nodemailer.createTransport({
   host: "smtp.gmail.com",
   secure: false, 
   auth: {
-    user: "peerprep17@gmail.com",
-    pass: "ztud otnc ixyt kfwo"
+    user: process.env.GMAIL_USER,
+    pass: process.env.GMAIL_PASSWORD,
   },
 });
 export default transporter;


### PR DESCRIPTION
- update .env for user-service with TEMPORARY_TOKEN_SECRET, GMAIL_USER, GMAIL_PASSWORD (btw the password isnt the gmail password so even though i revealed it in the first push, its fine)
- send a POST request to `http://localhost:8000/send-reset-email`
- using nodemailer, this would send an email to the user with the jwt token (signed using email, i'm not sure if there are other better ways like signing using the entire user object instead) i created a peer prep gmail cuz i didn't want to dox my variables
- user can then reset the password by sending a POST request to `http://localhost:8000/reset-password?token=...` where the token would be verified 

(u can sign up with ur real email on the app, then try to send an email to urself, it shd work) 
# Not done
- on the frontend side, prolly after user clicks on Forgot Password, they should then be able to input their email so the link can be sent to their email 
- there also needs to be a reset password form with the new password 

# Request for email
<img width="629" alt="Screenshot 2023-09-30 at 10 58 13 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/96589109/d5fb39b5-82b3-4b89-aae2-edbcf4dd3eb2">

After sending the email to myself with a post request (btw it keeps going to spam folder)

<img width="611" alt="Screenshot 2023-09-30 at 11 00 12 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/96589109/83475b07-f397-4505-81a6-143555859b9e">

# Reset password
I tried, the password should be updated in the app too
<img width="631" alt="Screenshot 2023-09-30 at 10 59 13 PM" src="https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/96589109/5160d256-367a-4a73-b625-534533173278">


