### PR TITLE
fix: global socket issue

### DIFF
--- a/backend/collaboration-service/app.ts
+++ b/backend/collaboration-service/app.ts
@@ -124,18 +124,22 @@ io.on("connection", (socket) => {
   });
 
   socket.on("user-agreed-next", (roomId, userId) => {
+    console.log(`User ${userId} agreed next question`);
     usersAgreedNext[roomId] = usersAgreedNext[roomId] || {};
     usersAgreedNext[roomId][userId] = true;
     if (Object.keys(usersAgreedNext[roomId]).length === 2) {
-      io?.emit("both-users-agreed-next", roomId);
+      io.to(roomId).emit("both-users-agreed-next", roomId);
       usersAgreedNext[roomId] = {};
+      console.log("Both users agreed next question");
     } else {
-      io?.emit("waiting-for-other-user", roomId);
+      io.to(roomId).emit("waiting-for-other-user", roomId);
+      console.log("Waiting for other user");
     }
   });
 
-  socket.on("change-question", (nextQuestionId) => {
-    io?.emit("set-question", nextQuestionId);
+  socket.on("change-question", (nextQuestionId, roomId) => {
+    io.to(roomId).emit("set-question", nextQuestionId);
+    console.log(`User ${socket.data.username} changed question to ${nextQuestionId}`);
   });
 
   socket.on("user-agreed-end", (roomId, userId) => {
@@ -143,10 +147,10 @@ io.on("connection", (socket) => {
     usersAgreedEnd[roomId][userId] = true;
 
     if (Object.keys(usersAgreedEnd[roomId]).length === 2) {
-      io?.emit("both-users-agreed-end", roomId);
+      io.to(roomId).emit("both-users-agreed-end", roomId);
       usersAgreedEnd[roomId] = {};
     } else {
-      io?.emit("waiting-for-other-user-end", roomId);
+      io.to(roomId).emit("waiting-for-other-user-end", roomId);
     }
   });
 

--- a/backend/collaboration-service/app.ts
+++ b/backend/collaboration-service/app.ts
@@ -124,22 +124,18 @@ io.on("connection", (socket) => {
   });
 
   socket.on("user-agreed-next", (roomId, userId) => {
-    console.log(`User ${userId} agreed next question`);
     usersAgreedNext[roomId] = usersAgreedNext[roomId] || {};
     usersAgreedNext[roomId][userId] = true;
     if (Object.keys(usersAgreedNext[roomId]).length === 2) {
       io.to(roomId).emit("both-users-agreed-next", roomId);
       usersAgreedNext[roomId] = {};
-      console.log("Both users agreed next question");
     } else {
       io.to(roomId).emit("waiting-for-other-user", roomId);
-      console.log("Waiting for other user");
     }
   });
 
   socket.on("change-question", (nextQuestionId, roomId) => {
     io.to(roomId).emit("set-question", nextQuestionId);
-    console.log(`User ${socket.data.username} changed question to ${nextQuestionId}`);
   });
 
   socket.on("user-agreed-end", (roomId, userId) => {

--- a/frontend/src/pages/collaboration/CollaborationRoom.tsx
+++ b/frontend/src/pages/collaboration/CollaborationRoom.tsx
@@ -179,6 +179,7 @@ const CollaborationRoom: React.FC<CollaborationRoomProps> = ({ isMatchingRoom }:
       });
     });
     socket?.on('both-users-agreed-next', async (roomId: number) => {
+      console.log('Both users agreed to go to the next question');
       setAttemptedFirst(true);
       const nextQuestionResponse = await axios.get(collabServiceUrl + 'api/get-second-question', {
         params: {
@@ -195,7 +196,7 @@ const CollaborationRoom: React.FC<CollaborationRoomProps> = ({ isMatchingRoom }:
 
       const nextQuestionId = Number(nextQuestionData.questionID);
       setQuestionId(nextQuestionId);
-      socket?.emit('change-question', nextQuestionId);
+      socket?.emit('change-question', nextQuestionId, roomId);
     });
 
     socket?.on('both-users-agreed-end', (roomId: number) => {
@@ -222,10 +223,12 @@ const CollaborationRoom: React.FC<CollaborationRoomProps> = ({ isMatchingRoom }:
         <RoomInfo />
         {isMatchingRoom && (
           <>
-            <Button size="sm" onClick={handleNextQuestion} mx={4}>
-              Next Question
-            </Button>
-            <Button size="sm" onClick={handleEndSession}>
+            {!attemptedFirst && (
+              <Button size="sm" onClick={handleNextQuestion} mx={4}>
+                Next Question {attemptedFirst}
+              </Button>
+            )}
+            <Button size="sm" mx={4} onClick={handleEndSession}>
               End Session
             </Button>
           </>


### PR DESCRIPTION
- fixes multiple toasts appearing when user click next question or end session 
- solves multiple rooms interfering with one another (ending one session ends the other room oops)

initially i used 
io.emit which is "global" so it interferes
should use `io.to(roomId).emit("both-users-agreed-next", roomId);`

note:
1. If you want to emit to all connected clients, including the current one, you can use `io.to(roomId).emit("both-users-agreed-next", roomId);`
2. `socket.to(roomId).emit("both-users-agreed-next", roomId);`
This code emits the event to all connected clients in the specified room except for the current socket (the one that triggered the event).
3. `socket.emit("both-users-agreed-next", roomId);`
This code emits the event to the client that initiated the event (the current socket). It targets only the socket that triggered the event.