### PR TITLE
fix: add another environment variable for path

### DIFF
--- a/frontend/src/api/base.ts
+++ b/frontend/src/api/base.ts
@@ -11,7 +11,9 @@ export const userServiceClient = axios.create({
 });
 
 export const collabServiceClient = axios.create({
-  baseURL: process.env.REACT_APP_COLLABORATION_SERVICE_SOCKET_IO_BACKEND_URL,
+  baseURL:
+    process.env.REACT_APP_COLLABORATION_SERVICE_SOCKET_IO_BACKEND_URL +
+    (process.env.REACT_APP_COLLABORATION_API_PATH ?? ''),
   withCredentials: true,
 });
 


### PR DESCRIPTION
by some black magic i have to specify the socket.io url as only the api gateway's url without the part behind ("/api/matching/") or websocket closes before establishing on deployment (????????????)

![telegram-cloud-photo-size-5-6237787111327644364-y](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g17/assets/34371483/e3dddacd-053c-43e9-957f-6fd59ba12083)

i dont understand how this fixes it but it seems to make the socket.io work

but then i need this to fix the `check-authentication` api call

thanks